### PR TITLE
Bg layout

### DIFF
--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -38,6 +38,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
                 new Claim(ClaimTypes.Email, userProfile.Email),
+                new Claim(ClaimTypes.Role, userProfile.UserType.Name)
             };
 
             var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿@using System.Security.Claims
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -30,19 +31,24 @@
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tags" asp-action="Index">TAGS</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORIES</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="UserProfile" asp-action="Index">USERS</a>
-                            </li>
+                            @if (User.FindFirstValue(ClaimTypes.Role) == "Admin")
+                            {
+
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Tags" asp-action="Index">TAGS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Category" asp-action="Index">CATEGORIES</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="UserProfile" asp-action="Index">USERS</a>
+                                </li>
+                            }
                             <li class="nav-item mx-0 mx-lg-1">
                                 <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>
                         }
+
                         else
                         {
                             <li class="nav-item mx-0 mx-lg-1">
@@ -62,7 +68,9 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
-    @{await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
     @RenderSection("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
# Description

Modified the Nav to only show Users, Tags and Categories links to admins.  Users with Author access can now only see posts.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. Clone down the repository.
2. `git fetch -a`
3. `git checkout bg-Layout`
4. Navigate to the root directory for this repo (directory-to)/tabloidmvc-the-daily-debuggers
5. Start TabloidMVC.sln
6. Make sure your db is created with seed data. Run [01_TabloidMVC_Create_DB.sql](https://github.com/NewForce-Cohort-5/tabloidmvc-the-daily-debuggers/blob/main/SQL/01_TabloidMVC_Create_DB.sql) and [02_TabloidMVC_Seed_Data.sql](https://github.com/NewForce-Cohort-5/tabloidmvc-the-daily-debuggers/blob/main/SQL/02_TabloidMVC_Seed_Data.sql) queries in Visual Studio.
7. Start the server.
8. Log in as admin [admin@example.com](mailto:admin@example.com) (if not already logged in as admin).
9. You should see a normal navbar at the top with links to Home, Posts, Tags, Categories, Users, and Logout.
10. Logout and login as a non-admin user.
11. You should only see Home, Posts and Logout in the navbar.




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
